### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# CODEOWNERS info: https://help.github.com/en/articles/about-code-owners
-# Owners are automatically requested for review for PRs that changes code
-# that they own.
-* @hypermodeAI/docs @hypermodeAI/runtime


### PR DESCRIPTION
This file is being copied with the template and there's no way to exclude it unfortunately. Removing for simplicity.